### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small correction in the `.github/other-configurations/labeller.yml` file, updating the documentation label configuration to match the correct spelling of the license file.

* Changed the documentation label pattern from `"LICENSE"` to `"LICENCE"` to match the actual file name.