### PR TITLE
Add Copilot to list of default removals

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -6,7 +6,7 @@ const DEFAULT_REGEX_SOURCES = [
   "\\[bot\\]",
   // Matches tokenized bot names like -bot, +bot, .bot or bot end
   "(?:^|[+\\-._])bot(?:$|[+\\-._])",
-  // Matches GitHub Copilot co-author lines,
+  // Matches GitHub Copilot co-author lines
   "Copilot",
 ];
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds an additional regex pattern to the `DEFAULT_REGEX_SOURCES` array in `src/content.js` to improve bot detection. The new pattern specifically targets GitHub Copilot co-author lines.

Bot detection improvements:
* Added `"Copilot"` to the `DEFAULT_REGEX_SOURCES` array to match GitHub Copilot co-author lines.
