### PR TITLE
Add NPM dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,19 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "30 7 * * *"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      npm:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to add scheduled npm dependency updates. The main change is the introduction of a new npm update group with a specific cron schedule.

Dependabot configuration enhancements:

* Added a new npm package ecosystem configuration to `.github/dependabot.yml`, scheduling updates to run daily at 07:30 London time, targeting the `main` branch.
* Created an npm update group that applies to all version updates (`patch` and `minor`) for all npm packages.
