### PR TITLE
Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   common-pull-request-tasks:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor change to the workflow permissions in `.github/workflows/pull-request-tasks.yml`, setting the `permissions` field to an empty object instead of specifying read access for pull requests.