### PR TITLE
Update Prek Freeze Command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -125,7 +125,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -138,4 +138,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small adjustment to the `Justfile` related to how Prek dependencies are updated. The main change is switching the `prek-update-hooks` command to use `prek update --freeze` instead of `prek autoupdate`, which will freeze dependency versions during the update process. Additionally, the `prek-update-additional-dependencies` step has been removed from the main `update` workflow.

Most important changes:

Dependency update process:

* Changed the `prek-update-hooks` command to use `prek update --freeze` for freezing dependency versions during updates instead of using `prek autoupdate`.
* Removed the `prek-update-additional-dependencies` step from the main `update` workflow, so it is no longer run automatically as part of the standard update process.